### PR TITLE
Add sha256 in hash function

### DIFF
--- a/packages/lsag-ts/test/ringSignature/constructor.spec.ts
+++ b/packages/lsag-ts/test/ringSignature/constructor.spec.ts
@@ -129,7 +129,6 @@ it("Should throw if at least 1 response is 0 - secp256k1", () => {
       data.linkabilityFlag ? [data.linkabilityFlag] : [],
     ),
     secp256k1,
-    // config,
   );
 
   const keyImage = customMapped.mult(data.signerPrivKey);
@@ -155,7 +154,6 @@ it("Should throw if curve is invalid", () => {
       data.linkabilityFlag ? [data.linkabilityFlag] : [],
     ),
     secp256k1,
-    // config,
   );
 
   const keyImage = customMapped.mult(data.signerPrivKey);
@@ -178,7 +176,6 @@ it("Should pass if all parameters are valid - secp256k1", () => {
       data.linkabilityFlag ? [data.linkabilityFlag] : [],
     ),
     secp256k1,
-    // config,
   );
 
   const keyImage = customMapped.mult(data.signerPrivKey);
@@ -203,7 +200,6 @@ it("Should throw if at least 1 response is 0 - secp256k1", () => {
       data.linkabilityFlag ? [data.linkabilityFlag] : [],
     ),
     secp256k1,
-    // config,
   );
 
   const keyImage = customMapped.mult(data.signerPrivKey);

--- a/packages/lsag-ts/test/ringSignature/sign.spec.ts
+++ b/packages/lsag-ts/test/ringSignature/sign.spec.ts
@@ -89,4 +89,17 @@ describe("Test sign()", () => {
     expect(ringSignature).toBeInstanceOf(RingSignature);
     expect(ringSignature.verify()).toBe(true);
   });
+  /* ------------CONFIG.HASH = SHA256------------ */
+  it("Should return a valid ring signature if config.hash is SHA256 - secp256k1", () => {
+    const ringSignature = RingSignature.sign(
+      data.publicKeys_secp256k1,
+      data.signerPrivKey,
+      data.message,
+      secp256k1,
+      data.linkabilityFlag,
+      { hash: HashFunction.SHA256 },
+    );
+    expect(ringSignature).toBeInstanceOf(RingSignature);
+    expect(ringSignature.verify()).toBe(true);
+  });
 });

--- a/packages/lsag-ts/test/ringSignature/toBase64.spec.ts
+++ b/packages/lsag-ts/test/ringSignature/toBase64.spec.ts
@@ -17,7 +17,6 @@ describe("Test toBase64()", () => {
         data.linkabilityFlag ? [data.linkabilityFlag] : [],
       ),
       secp256k1,
-      // config,
     );
 
     const keyImage = customMapped.mult(data.signerPrivKey);
@@ -40,7 +39,6 @@ describe("Test toBase64()", () => {
         data.linkabilityFlag ? [data.linkabilityFlag] : [],
       ),
       secp256k1,
-      // config,
     );
 
     const keyImage = customMapped.mult(data.signerPrivKey);

--- a/packages/lsag-ts/test/ringSignature/toJsonString.spec.ts
+++ b/packages/lsag-ts/test/ringSignature/toJsonString.spec.ts
@@ -17,7 +17,6 @@ describe("Test toJsonString()", () => {
         data.linkabilityFlag ? [data.linkabilityFlag] : [],
       ),
       secp256k1,
-      // config,
     );
 
     const keyImage = customMapped.mult(data.signerPrivKey);
@@ -39,7 +38,6 @@ describe("Test toJsonString()", () => {
         data.linkabilityFlag ? [data.linkabilityFlag] : [],
       ),
       secp256k1,
-      // config,
     );
 
     const keyImage = customMapped.mult(data.signerPrivKey);

--- a/packages/ring-sig-utils/src/utils/hashFunction.ts
+++ b/packages/ring-sig-utils/src/utils/hashFunction.ts
@@ -1,6 +1,7 @@
 import { keccak_256 as keccak256 } from "@noble/hashes/sha3";
 import { utf8ToBytes } from "@noble/hashes/utils";
 import { sha512 } from "@noble/hashes/sha512";
+import { sha256 } from "@noble/hashes/sha256";
 import { SignatureConfig } from "../interfaces";
 import { uint8ArrayToHex } from ".";
 import { Curve, CurveName } from "../curves";
@@ -10,6 +11,7 @@ import { hashToCurve } from "@noble/curves/secp256k1";
 export enum HashFunction {
   KECCAK256 = "keccak256",
   SHA512 = "sha512",
+  SHA256 = "sha256",
 }
 
 /* ------------------ Hash functions ------------------ */
@@ -34,6 +36,9 @@ export function hash(
     }
     case HashFunction.SHA512: {
       return sha_512(data);
+    }
+    case HashFunction.SHA256: {
+      return sha_256(data);
     }
     default: {
       return keccak_256(data, config?.evmCompatibility);
@@ -91,10 +96,18 @@ export function keccak_256(
  * @returns - The hash of the data  as an hex string
  */
 export function sha_512(input: (string | bigint)[]): string {
-  const serialized = input
-    .map((x) => (typeof x === "bigint" ? x.toString() : x))
-    .join("");
-  return Buffer.from(sha512(serialized)).toString("hex");
+  return Buffer.from(sha512(serializeInput(input))).toString("hex");
+}
+
+/**
+ * Hash data using sha256
+ *
+ * @param input - The data to hash
+ *
+ * @returns - The hash of the data as an hex string
+ */
+export function sha_256(input: (string | bigint)[]): string {
+  return Buffer.from(sha256(serializeInput(input))).toString("hex");
 }
 
 /**

--- a/packages/sag-ts/test/ringSignature/constructor.spec.ts
+++ b/packages/sag-ts/test/ringSignature/constructor.spec.ts
@@ -199,6 +199,20 @@ describe("Test Constructor", () => {
           ),
       );
     });
+    it("Should pass if config.hash is sha256", () => {
+      expect(
+        () =>
+          new RingSignature(
+            data.message,
+            data.publicKeys_ed25519,
+            data.randomC,
+            data.randomResponses,
+            ed25519,
+            { hash: HashFunction.SHA256 },
+          ),
+      );
+    });
+
     it("Should pass if config.hash is not undefined", () => {
       expect(
         () =>

--- a/packages/sag-ts/test/ringSignature/sign.spec.ts
+++ b/packages/sag-ts/test/ringSignature/sign.spec.ts
@@ -130,6 +130,17 @@ describe("Test sign()", () => {
     expect(ringSignature).toBeInstanceOf(RingSignature);
     expect(ringSignature.verify()).toBe(true);
   });
+  it("Should return a valid ring signature if config.hash is SHA256 - secp256k1", () => {
+    const ringSignature = RingSignature.sign(
+      data.publicKeys_secp256k1,
+      data.signerPrivKey,
+      data.message,
+      secp256k1,
+      { hash: HashFunction.SHA256 },
+    );
+    expect(ringSignature).toBeInstanceOf(RingSignature);
+    expect(ringSignature.verify()).toBe(true);
+  });
 
   it("Should return a valid ring signature if config.hash is SHA512 - ed25519", () => {
     const ringSignature = RingSignature.sign(
@@ -138,6 +149,17 @@ describe("Test sign()", () => {
       data.message,
       ed25519,
       { hash: HashFunction.SHA512 },
+    );
+    expect(ringSignature).toBeInstanceOf(RingSignature);
+    expect(ringSignature.verify()).toBe(true);
+  });
+  it("Should return a valid ring signature if config.hash is SHA256 - ed25519", () => {
+    const ringSignature = RingSignature.sign(
+      data.publicKeys_ed25519,
+      data.signerPrivKey,
+      data.message,
+      ed25519,
+      { hash: HashFunction.SHA256 },
     );
     expect(ringSignature).toBeInstanceOf(RingSignature);
     expect(ringSignature.verify()).toBe(true);


### PR DESCRIPTION
This pull request aims to add support for SHA-256 in the hash function utilities. This enhancement is motivated by the availability of the accelerated crate on RISC-Zero that is specifically optimized for SHA-256. Using SHA-256 instead of Keccak for verifying a LSAG on RISC-Zero results in nearly a 4% reduction in the number of cycles required.